### PR TITLE
CMake: check X11 library dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,10 @@ list(APPEND VT_XLIBS Freetype::Freetype)
 pkg_check_modules(FONTCONFIG REQUIRED fontconfig)
 list(APPEND VT_XLIBS ${FONTCONFIG_LIBRARIES})
 
+foreach(vt_xlib ${VT_XLIBS})
+    message(STATUS "Linking ${vt_xlib}")
+endforeach()
+
 add_library(vtcore
     main/admission.cc  main/admission.hh
     external/sha1.cc   external/sha1.hh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,9 @@ foreach(vt_xlib ${VT_XLIBS})
 endforeach()
 
 list(REMOVE_DUPLICATES VT_XLIBS_INCLUDE_DIRS)
+foreach(vt_xlib_include ${VT_XLIBS_INCLUDE_DIRS})
+    message(STATUS "Include X11 code from ${vt_xlib_include}")
+endforeach()
 
 add_library(vtcore
     main/admission.cc  main/admission.hh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,10 +106,13 @@ target_link_libraries(conf_file PRIVATE ZLIB::ZLIB)
 
 set(VT_XLIBS X11)
 find_package(${VT_XLIBS} REQUIRED)
+set(VT_XLIBS_INCLUDE_DIRS ${X11_INCLUDE_DIR})
 set(x11_required_libraries Xft Xmu Xpm Xrender Xt)
 foreach(x11_requirement ${x11_required_libraries})
     if(NOT DEFINED X11_${x11_requirement}_FOUND)
         list(APPEND x11_missing_requirements "${x11_requirement}")
+    else()
+        list(APPEND VT_XLIBS_INCLUDE_DIRS "${X11_${x11_requirement}_INCLUDE_PATH}")
     endif()
 endforeach()
 if(DEFINED x11_missing_requirements)
@@ -122,16 +125,20 @@ list(APPEND VT_XLIBS ${x11_required_libraries})
 
 find_package(Motif REQUIRED)
 list(APPEND VT_XLIBS ${MOTIF_LIBRARIES})
+list(APPEND VT_XLIBS_INCLUDE_DIRS ${MOTIF_INCLUDE_DIR})
 
 find_package(Freetype REQUIRED)
 list(APPEND VT_XLIBS Freetype::Freetype)
 
 pkg_check_modules(FONTCONFIG REQUIRED fontconfig)
 list(APPEND VT_XLIBS ${FONTCONFIG_LIBRARIES})
+list(APPEND VT_XLIBS_INCLUDE_DIRS ${FONTCONFIG_INCLUDE_DIRS})
 
 foreach(vt_xlib ${VT_XLIBS})
     message(STATUS "Linking ${vt_xlib}")
 endforeach()
+
+list(REMOVE_DUPLICATES VT_XLIBS_INCLUDE_DIRS)
 
 add_library(vtcore
     main/admission.cc  main/admission.hh
@@ -223,6 +230,7 @@ add_executable(vt_main
     main/cdu.cc             main/cdu.hh
     main/cdu_att.cc         main/cdu_att.hh
     )
+target_include_directories(vt_main PRIVATE ${VT_XLIBS_INCLUDE_DIRS})
 target_link_libraries(vt_main zone vtcore ${VT_XLIBS})
 target_link_libraries(vt_main tz)
 
@@ -238,6 +246,7 @@ add_executable(vt_term
     term/term_dialog.hh
     term/term_${TERM_CREDIT}.cc)
 
+target_include_directories(vt_term PRIVATE ${VT_XLIBS_INCLUDE_DIRS})
 target_link_libraries(vt_term
     vtcore conf_file image_data
     ${VT_XLIBS} ${TERM_CREDIT_LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,31 @@ add_library(image_data STATIC
 
 find_package(ZLIB REQUIRED)
 target_link_libraries(conf_file PRIVATE ZLIB::ZLIB)
-set(VT_XLIBS X11 Xm Xmu Xt Xpm Xft freetype fontconfig Xrender)
+
+set(VT_XLIBS X11)
+find_package(${VT_XLIBS} REQUIRED)
+set(x11_required_libraries Xft Xmu Xpm Xrender Xt)
+foreach(x11_requirement ${x11_required_libraries})
+    if(NOT DEFINED X11_${x11_requirement}_FOUND)
+        list(APPEND x11_missing_requirements "${x11_requirement}")
+    endif()
+endforeach()
+if(DEFINED x11_missing_requirements)
+    foreach(x11_lib_missing ${x11_missing_requirements})
+        message(STATUS "X11: ${x11_lib_missing} library missing")
+    endforeach()
+    message(FATAL_ERROR "Missing X library dependencies")
+endif()
+list(APPEND VT_XLIBS ${x11_required_libraries})
+
+find_package(Motif REQUIRED)
+list(APPEND VT_XLIBS ${MOTIF_LIBRARIES})
+
+find_package(Freetype REQUIRED)
+list(APPEND VT_XLIBS Freetype::Freetype)
+
+pkg_check_modules(FONTCONFIG REQUIRED fontconfig)
+list(APPEND VT_XLIBS ${FONTCONFIG_LIBRARIES})
 
 add_library(vtcore
     main/admission.cc  main/admission.hh


### PR DESCRIPTION
When I started building the project in an Ubuntu Docker container I intentionally installed no dependencies other than the compiler. The GTK requirement was checked by CMake, but X libraries were simply assumed and only failed at build time. This PR is intended to check these dependencies at configuration time and fail with an error message instead of a compile error.

I've tested with and without X dependencies available and the configure step was only finished successfully when all dependencies were met. If the configure step finished the build step succeeded also. I did not run any further test by now.

@NeroBurner :
The two debug output commits should probably be removed before pushing upstream, but are left here for you to check.

Please take a look at these commits (especially my lousy CMake) and improve/change/squash/test as you see need before sending this upstream.